### PR TITLE
Fix build failure and restore published blog post visibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [master]
   push:
-    branches: [main]
+    branches: [master]
 
 permissions:
   contents: read

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -19,7 +19,8 @@ const nextConfig = {
 
   experimental: {
     /** Tree-shake heavy barrel exports at build time. */
-    optimizePackageImports: ["react-icons", "@once-ui-system/core"],
+    // Do not add @once-ui-system/core here — it breaks prerender (undefined components).
+    optimizePackageImports: ["react-icons"],
   },
 
   turbopack: {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@csstools/postcss-global-data": "^4.0.0",
     "@mdx-js/loader": "^3.1.1",
     "@next/mdx": "^16.2.7",
-    "@once-ui-system/core": "latest",
+    "@once-ui-system/core": "1.7.12",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
     "classnames": "^2.5.1",

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -22,6 +22,8 @@ import {
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 
+export const revalidate = 300;
+
 export async function generateStaticParams(): Promise<{ slug: string }[]> {
   const posts = await getBlogPosts();
   return posts.map((post) => ({

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,9 +1,12 @@
 import { Mailchimp } from "@/components";
+import { BlogPostsLazy } from "@/components/blog/BlogPostsLazy";
 import Post from "@/components/blog/Post";
-import { getBlogPosts } from "@/lib/blog-posts";
-import { API_ENDPOINTS } from "@/lib/constants";
+import { getBlogPostsPaginated } from "@/lib/blog-posts";
+import { API_ENDPOINTS, BLOG_CONFIG } from "@/lib/constants";
 import { baseURL, blog, person } from "@/resources";
 import { Column, Grid, Heading, Meta, Schema } from "@once-ui-system/core";
+
+export const revalidate = 300;
 
 export async function generateMetadata() {
   return Meta.generate({
@@ -16,12 +19,11 @@ export async function generateMetadata() {
 }
 
 export default async function Blog() {
-  const allPosts = await getBlogPosts();
-  const posts = allPosts.map(({ content: _content, ...rest }) => rest);
+  const { posts: initialPosts, total } = await getBlogPostsPaginated(0, BLOG_CONFIG.INITIAL_PAGE_SIZE);
 
-  const featured = posts[0];
-  const spotlight = posts.slice(1, 3);
-  const earlier = posts.slice(3);
+  const featured = initialPosts[0];
+  const spotlight = initialPosts.slice(1, 3);
+  const earlier = initialPosts.slice(3);
 
   return (
     <Column maxWidth="m" paddingTop="24" fillWidth>
@@ -52,16 +54,19 @@ export default async function Blog() {
           </Grid>
         )}
 
-        {earlier.length > 0 && (
+        {(earlier.length > 0 || total > BLOG_CONFIG.INITIAL_PAGE_SIZE) && (
           <Column fillWidth gap="24">
             <Heading as="h2" variant="heading-strong-xl">
               Earlier posts
             </Heading>
-            <Grid columns="2" s={{ columns: 1 }} fillWidth gap="16">
-              {earlier.map((post, index) => (
-                <Post key={post.slug} post={post} thumbnail index={index + 3} />
-              ))}
-            </Grid>
+            <BlogPostsLazy
+              initialPosts={earlier}
+              total={total}
+              startOffset={initialPosts.length}
+              pageSize={BLOG_CONFIG.LAZY_PAGE_SIZE}
+              columns="2"
+              thumbnail
+            />
           </Column>
         )}
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,7 +8,7 @@ import classNames from "classnames";
 
 import { Footer, Header, Providers, RouteGuard } from "@/components";
 import { baseURL, dataStyle, effects, fonts, home, style } from "@/resources";
-import type { Opacity } from "@once-ui-system/core";
+import type { OnceUiOpacity } from "@/types";
 import { Background, Column, Flex, Meta, RevealFx, SpacingToken } from "@once-ui-system/core";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 
@@ -105,7 +105,7 @@ export default async function RootLayout({
                 }}
                 gradient={{
                   display: effects.gradient.display,
-                  opacity: effects.gradient.opacity as Opacity,
+                  opacity: effects.gradient.opacity as OnceUiOpacity,
                   x: effects.gradient.x,
                   y: effects.gradient.y,
                   width: effects.gradient.width,
@@ -116,20 +116,20 @@ export default async function RootLayout({
                 }}
                 dots={{
                   display: effects.dots.display,
-                  opacity: effects.dots.opacity as Opacity,
+                  opacity: effects.dots.opacity as OnceUiOpacity,
                   size: effects.dots.size as SpacingToken,
                   color: effects.dots.color,
                 }}
                 grid={{
                   display: effects.grid.display,
-                  opacity: effects.grid.opacity as Opacity,
+                  opacity: effects.grid.opacity as OnceUiOpacity,
                   color: effects.grid.color,
                   width: effects.grid.width,
                   height: effects.grid.height,
                 }}
                 lines={{
                   display: effects.lines.display,
-                  opacity: effects.lines.opacity as Opacity,
+                  opacity: effects.lines.opacity as OnceUiOpacity,
                   size: effects.lines.size as SpacingToken,
                   thickness: effects.lines.thickness,
                   angle: effects.lines.angle,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,7 +8,8 @@ import classNames from "classnames";
 
 import { Footer, Header, Providers, RouteGuard } from "@/components";
 import { baseURL, dataStyle, effects, fonts, home, style } from "@/resources";
-import { Background, Column, Flex, Meta, opacity, RevealFx, SpacingToken } from "@once-ui-system/core";
+import type { Opacity } from "@once-ui-system/core";
+import { Background, Column, Flex, Meta, RevealFx, SpacingToken } from "@once-ui-system/core";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 
 export async function generateMetadata() {
@@ -104,7 +105,7 @@ export default async function RootLayout({
                 }}
                 gradient={{
                   display: effects.gradient.display,
-                  opacity: effects.gradient.opacity as opacity,
+                  opacity: effects.gradient.opacity as Opacity,
                   x: effects.gradient.x,
                   y: effects.gradient.y,
                   width: effects.gradient.width,
@@ -115,20 +116,20 @@ export default async function RootLayout({
                 }}
                 dots={{
                   display: effects.dots.display,
-                  opacity: effects.dots.opacity as opacity,
+                  opacity: effects.dots.opacity as Opacity,
                   size: effects.dots.size as SpacingToken,
                   color: effects.dots.color,
                 }}
                 grid={{
                   display: effects.grid.display,
-                  opacity: effects.grid.opacity as opacity,
+                  opacity: effects.grid.opacity as Opacity,
                   color: effects.grid.color,
                   width: effects.grid.width,
                   height: effects.grid.height,
                 }}
                 lines={{
                   display: effects.lines.display,
-                  opacity: effects.lines.opacity as opacity,
+                  opacity: effects.lines.opacity as Opacity,
                   size: effects.lines.size as SpacingToken,
                   thickness: effects.lines.thickness,
                   angle: effects.lines.angle,

--- a/src/components/Mailchimp.tsx
+++ b/src/components/Mailchimp.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import { mailchimp, newsletter } from "@/resources";
+import type { Opacity } from "@once-ui-system/core";
 import {
   Background,
   Button,
   Column,
   Heading,
   Input,
-  opacity,
   Row,
   SpacingToken,
   Text,
@@ -82,7 +82,7 @@ export const Mailchimp: React.FC<React.ComponentProps<typeof Column>> = ({ ...fl
         }}
         gradient={{
           display: mailchimp.effects.gradient.display,
-          opacity: mailchimp.effects.gradient.opacity as opacity,
+          opacity: mailchimp.effects.gradient.opacity as Opacity,
           x: mailchimp.effects.gradient.x,
           y: mailchimp.effects.gradient.y,
           width: mailchimp.effects.gradient.width,
@@ -93,20 +93,20 @@ export const Mailchimp: React.FC<React.ComponentProps<typeof Column>> = ({ ...fl
         }}
         dots={{
           display: mailchimp.effects.dots.display,
-          opacity: mailchimp.effects.dots.opacity as opacity,
+          opacity: mailchimp.effects.dots.opacity as Opacity,
           size: mailchimp.effects.dots.size as SpacingToken,
           color: mailchimp.effects.dots.color,
         }}
         grid={{
           display: mailchimp.effects.grid.display,
-          opacity: mailchimp.effects.grid.opacity as opacity,
+          opacity: mailchimp.effects.grid.opacity as Opacity,
           color: mailchimp.effects.grid.color,
           width: mailchimp.effects.grid.width,
           height: mailchimp.effects.grid.height,
         }}
         lines={{
           display: mailchimp.effects.lines.display,
-          opacity: mailchimp.effects.lines.opacity as opacity,
+          opacity: mailchimp.effects.lines.opacity as Opacity,
           size: mailchimp.effects.lines.size as SpacingToken,
           thickness: mailchimp.effects.lines.thickness,
           angle: mailchimp.effects.lines.angle,

--- a/src/components/Mailchimp.tsx
+++ b/src/components/Mailchimp.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { mailchimp, newsletter } from "@/resources";
-import type { Opacity } from "@once-ui-system/core";
+import type { OnceUiOpacity } from "@/types";
 import {
   Background,
   Button,
@@ -82,7 +82,7 @@ export const Mailchimp: React.FC<React.ComponentProps<typeof Column>> = ({ ...fl
         }}
         gradient={{
           display: mailchimp.effects.gradient.display,
-          opacity: mailchimp.effects.gradient.opacity as Opacity,
+          opacity: mailchimp.effects.gradient.opacity as OnceUiOpacity,
           x: mailchimp.effects.gradient.x,
           y: mailchimp.effects.gradient.y,
           width: mailchimp.effects.gradient.width,
@@ -93,20 +93,20 @@ export const Mailchimp: React.FC<React.ComponentProps<typeof Column>> = ({ ...fl
         }}
         dots={{
           display: mailchimp.effects.dots.display,
-          opacity: mailchimp.effects.dots.opacity as Opacity,
+          opacity: mailchimp.effects.dots.opacity as OnceUiOpacity,
           size: mailchimp.effects.dots.size as SpacingToken,
           color: mailchimp.effects.dots.color,
         }}
         grid={{
           display: mailchimp.effects.grid.display,
-          opacity: mailchimp.effects.grid.opacity as Opacity,
+          opacity: mailchimp.effects.grid.opacity as OnceUiOpacity,
           color: mailchimp.effects.grid.color,
           width: mailchimp.effects.grid.width,
           height: mailchimp.effects.grid.height,
         }}
         lines={{
           display: mailchimp.effects.lines.display,
-          opacity: mailchimp.effects.lines.opacity as Opacity,
+          opacity: mailchimp.effects.lines.opacity as OnceUiOpacity,
           size: mailchimp.effects.lines.size as SpacingToken,
           thickness: mailchimp.effects.lines.thickness,
           angle: mailchimp.effects.lines.angle,

--- a/src/lib/blog-posts.ts
+++ b/src/lib/blog-posts.ts
@@ -71,7 +71,8 @@ function mapSyncAppPost(post: SyncAppPost): BlogPost {
 }
 
 function isPublishedPost(post: SyncAppPost): boolean {
-  return !post.status || post.status === PUBLISHED_STATUS;
+  if (!post.status) return true;
+  return post.status.toLowerCase() === PUBLISHED_STATUS;
 }
 
 async function fetchSyncAppPostBySlug(slug: string): Promise<BlogPost | null> {
@@ -96,20 +97,22 @@ async function fetchAllSyncAppPosts(): Promise<BlogPost[]> {
   let totalPages = 1;
 
   try {
-    while (page <= totalPages) {
-      const res = await syncAppFetch(`/posts?page=${page}&limit=${SYNCAPP_PAGE_LIMIT}`);
+    do {
+      const res = await syncAppFetch(`/posts?page=${page}&limit=${SYNCAPP_PAGE_LIMIT}&status=${PUBLISHED_STATUS}`);
 
       if (!res.ok) {
-        console.warn(`SyncApp posts list failed: ${res.status}`);
+        console.warn(`SyncApp posts list failed (page ${page}): ${res.status}`);
         break;
       }
 
       const json = (await res.json()) as SyncAppListResponse;
       const pagePosts = (json.data || []).filter(isPublishedPost);
       posts.push(...pagePosts);
-      totalPages = json.pagination?.totalPages || 1;
+
+      const reportedTotalPages = json.pagination?.totalPages;
+      totalPages = reportedTotalPages && reportedTotalPages > 0 ? reportedTotalPages : page;
       page += 1;
-    }
+    } while (page <= totalPages);
   } catch (error) {
     console.warn("Failed to fetch SyncApp posts:", error);
     return [];

--- a/src/lib/syncapp.ts
+++ b/src/lib/syncapp.ts
@@ -7,7 +7,13 @@ import { SYNCAPP_CONFIG } from "./constants/syncapp";
 export function getSyncAppApiBase(): string {
   const envUrl = process.env.SYNCAPP_API_URL?.trim();
   if (envUrl) {
-    return envUrl.endsWith("/api") ? envUrl : `${envUrl.replace(/\/$/, "")}/api`;
+    const normalized = envUrl.endsWith("/api") ? envUrl : `${envUrl.replace(/\/$/, "")}/api`;
+    const isLocalhost = /localhost|127\.0\.0\.1/i.test(normalized);
+    if (isLocalhost && process.env.NODE_ENV === "production") {
+      console.warn("SYNCAPP_API_URL points to localhost in production; using default API base instead.");
+      return SYNCAPP_CONFIG.PRODUCTION_API_BASE;
+    }
+    return normalized;
   }
 
   return SYNCAPP_CONFIG.PRODUCTION_API_BASE;

--- a/src/resources/once-ui.config.ts
+++ b/src/resources/once-ui.config.ts
@@ -43,7 +43,7 @@ const protectedRoutes: ProtectedRoutesConfig = {
 
 // Import and set font for each variant
 import { Geist, Geist_Mono } from "next/font/google";
-3;
+
 const heading = Geist({
   variable: "--font-heading",
   subsets: ["latin"],

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -13,6 +13,9 @@ import {
 } from "@once-ui-system/core";
 import { NextFontWithVariable } from "next/dist/compiled/@next/font";
 
+/** Once UI opacity scale for Background effects (avoids importing renamed package types). */
+export type OnceUiOpacity = 0 | 10 | 20 | 30 | 40 | 50 | 60 | 70 | 80 | 90 | 100;
+
 /**
  * Display configuration for UI elements.
  */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the production build failure and improves how published SyncApp blog posts are fetched and displayed on the blog page.

## Build failure (root cause)

The build was failing at the TypeScript step because `@once-ui-system/core` renamed the export from `opacity` to `Opacity`. After fixing that, a second hidden issue surfaced during prerender: `optimizePackageImports` for `@once-ui-system/core` caused undefined components at build time (`/_not-found` prerender error).

**Fix:** Use a local `OnceUiOpacity` type (avoids package export naming drift) and remove `@once-ui-system/core` from `optimizePackageImports`.

## Vercel CI failure (root cause)

GitHub Actions passed, but the **Vercel** check failed because `package-lock.json` is gitignored and `@once-ui-system/core` was set to `"latest"`. Vercel resolved an older package version exporting lowercase `opacity`, while local/CI resolved a newer version with `Opacity`.

**Fix:** Pin `@once-ui-system/core` to `1.7.12` and use the local `OnceUiOpacity` type instead of importing from the package.

## Blog visibility

- Restored `BlogPostsLazy` on `/blog` so all published posts load beyond the first page batch
- Added case-insensitive published status filtering for SyncApp posts
- Fixed pagination edge case when `totalPages` is missing or zero
- Added `revalidate = 300` on blog routes so new SyncApp posts appear within 5 minutes
- Added production safeguard: if `SYNCAPP_API_URL` points to localhost in production, fall back to the default SyncApp API base

## Other

- Fixed CI workflow to run on `master` (was incorrectly configured for `main`)
- Removed stray `3;` syntax in `once-ui.config.ts`

## Verification

- `npm run lint` passes
- `npm run build` passes
- Build generates 13 blog slugs (8 SyncApp + 5 local MDX)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6f3c-85f1-7230-9440-9b442e890878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6f3c-85f1-7230-9440-9b442e890878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

