### PR TITLE
Fix blog visibility: SSR all posts and restore homepage Posts

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,8 +1,7 @@
 import { Mailchimp } from "@/components";
-import { BlogPostsLazy } from "@/components/blog/BlogPostsLazy";
 import Post from "@/components/blog/Post";
-import { getBlogPostsPaginated } from "@/lib/blog-posts";
-import { API_ENDPOINTS, BLOG_CONFIG } from "@/lib/constants";
+import { getBlogPosts } from "@/lib/blog-posts";
+import { API_ENDPOINTS } from "@/lib/constants";
 import { baseURL, blog, person } from "@/resources";
 import { Column, Grid, Heading, Meta, Schema } from "@once-ui-system/core";
 
@@ -19,11 +18,12 @@ export async function generateMetadata() {
 }
 
 export default async function Blog() {
-  const { posts: initialPosts, total } = await getBlogPostsPaginated(0, BLOG_CONFIG.INITIAL_PAGE_SIZE);
+  const allPosts = await getBlogPosts();
+  const posts = allPosts.map(({ content: _content, ...rest }) => rest);
 
-  const featured = initialPosts[0];
-  const spotlight = initialPosts.slice(1, 3);
-  const earlier = initialPosts.slice(3);
+  const featured = posts[0];
+  const spotlight = posts.slice(1, 3);
+  const earlier = posts.slice(3);
 
   return (
     <Column maxWidth="m" paddingTop="24" fillWidth>
@@ -54,19 +54,16 @@ export default async function Blog() {
           </Grid>
         )}
 
-        {(earlier.length > 0 || total > BLOG_CONFIG.INITIAL_PAGE_SIZE) && (
+        {earlier.length > 0 && (
           <Column fillWidth gap="24">
             <Heading as="h2" variant="heading-strong-xl">
               Earlier posts
             </Heading>
-            <BlogPostsLazy
-              initialPosts={earlier}
-              total={total}
-              startOffset={initialPosts.length}
-              pageSize={BLOG_CONFIG.LAZY_PAGE_SIZE}
-              columns="2"
-              thumbnail
-            />
+            <Grid columns="2" s={{ columns: 1 }} fillWidth gap="16">
+              {earlier.map((post, index) => (
+                <Post key={post.slug} post={post} thumbnail index={index + 3} />
+              ))}
+            </Grid>
           </Column>
         )}
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,8 +2,8 @@ import { API_ENDPOINTS, ROUTES } from "@/lib/constants";
 import { about, baseURL, home, person, routes } from "@/resources";
 import { Avatar, Badge, Button, Column, Heading, Line, Meta, RevealFx, Row, Schema, Text } from "@once-ui-system/core";
 import dynamic from "next/dynamic";
+import { Posts } from "@/components/blog/Posts";
 
-const Posts = dynamic(() => import("@/components/blog/Posts").then((mod) => mod.Posts));
 const Mailchimp = dynamic(() => import("@/components").then((mod) => mod.Mailchimp));
 
 export async function generateMetadata() {

--- a/src/components/blog/Post.tsx
+++ b/src/components/blog/Post.tsx
@@ -19,7 +19,7 @@ export default function Post({ post, thumbnail, direction, index = 0, priority =
   const revealDelay = Math.min(index * 0.08, 0.48);
 
   return (
-    <RevealFx fillWidth translateY={12} delay={revealDelay} speed="fast">
+    <RevealFx fillWidth translateY={12} delay={revealDelay} speed="fast" revealedByDefault>
       <Card
         fillWidth
         href={`${ROUTES.BLOG}/${post.slug}`}

--- a/src/lib/blog-posts.ts
+++ b/src/lib/blog-posts.ts
@@ -29,7 +29,9 @@ interface SyncAppPost {
   tags?: string[];
   cover_image?: string;
   meta_description?: string;
-  createdAt: string;
+  createdAt?: string;
+  created_at?: string;
+  is_published_anywhere?: boolean;
 }
 
 interface SyncAppListResponse {
@@ -53,6 +55,11 @@ function extractSummary(content: string): string {
 
 function mapSyncAppPost(post: SyncAppPost): BlogPost {
   const content = post.content_markdown || "";
+  const publishedRaw = post.createdAt || post.created_at || new Date().toISOString();
+  const publishedAt = new Date(publishedRaw);
+  const publishedDate = Number.isNaN(publishedAt.getTime())
+    ? new Date().toISOString().split("T")[0]
+    : publishedAt.toISOString().split("T")[0];
 
   return {
     slug: post.slug,
@@ -60,7 +67,7 @@ function mapSyncAppPost(post: SyncAppPost): BlogPost {
     source: "syncapp",
     metadata: {
       title: post.title,
-      publishedAt: new Date(post.createdAt).toISOString().split("T")[0],
+      publishedAt: publishedDate,
       summary: post.meta_description?.trim() || extractSummary(content),
       image: post.cover_image || "",
       images: post.cover_image ? [post.cover_image] : [],
@@ -71,6 +78,7 @@ function mapSyncAppPost(post: SyncAppPost): BlogPost {
 }
 
 function isPublishedPost(post: SyncAppPost): boolean {
+  if (post.is_published_anywhere) return true;
   if (!post.status) return true;
   return post.status.toLowerCase() === PUBLISHED_STATUS;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Production still had missing blog posts after #19. This PR fixes the remaining visibility bugs.

## Root causes

1. **Homepage “Latest from the blog” was empty**  
   `Posts` is an async Server Component, but it was wrapped in `next/dynamic()`. That broke rendering — the section title showed, but no `/blog/...` links were emitted.

2. **`/blog` only SSR’d the first 10 posts**  
   Lazy-loading (`BlogPostsLazy`) meant the last 3 posts (local MDX) only appeared after a client fetch + IntersectionObserver. Without scrolling/JS, they never showed in the page HTML.

3. **Cards started visually hidden**  
   `RevealFx` without `revealedByDefault` rendered posts with `translateY(12rem)` + a full mask until hydration. They looked “missing” until client JS ran.

## Fixes

- Import `Posts` directly on the homepage (keep `dynamic()` only for client `Mailchimp`)
- SSR **all** published posts on `/blog` (no truncated first page)
- Set `revealedByDefault` on blog `Post` cards so they are visible in HTML immediately
- Harden SyncApp mapping for `created_at` / `is_published_anywhere`

## Verification

- `npm run lint` / `npm run build` pass
- Local SSR: homepage has 2 blog links; `/blog` has **all 13** post links with `translateY(0)`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6f3c-85f1-7230-9440-9b442e890878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6f3c-85f1-7230-9440-9b442e890878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

